### PR TITLE
Add part hashes to header even with pre-computed signature file

### DIFF
--- a/src/sign.c
+++ b/src/sign.c
@@ -280,6 +280,9 @@ int action_sign(int argc, char **argv)
 
     FILE *sig_fp = NULL;
 
+    size_t hash_size = sizeof(hash_output);
+    bpak_pkg_compute_hash(pkg, hash_output, &hash_size);
+
     /* Set pre-computed signature */
     if (signature_file)
     {
@@ -294,9 +297,6 @@ int action_sign(int argc, char **argv)
     }
     else
     {
-        size_t hash_size = sizeof(hash_output);
-        bpak_pkg_compute_hash(pkg, hash_output, &hash_size);
-
         if (bpak_get_verbosity())
         {
             printf("Computed hash: ");


### PR DESCRIPTION
One-step signing:
1. bpak sign archive.bpak --key privkey.pem

Part hashes are calculated and added to the header, which is then
hashed. The modified header is saved to the bpak file.

Two-step signing:
1. bpak show archive.bpak --hash > hash
2. <sign hash>
3. bpak sign archive.bpak --signature hash.signed

Part hashes are calculated in step 1 and added to the header in RAM
before hashing. This commit makes bpak calculate the part hashes in
step 3 as well and write them to the header in the file.